### PR TITLE
Check metadata presence when getting param types

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mocha-reporter": "0.0.3",
     "npm-run-all": "4.0.2",
     "nyc": "11.3.0",
+    "sinon": "5.0.7",
     "ts-node": "3.1.0",
     "tslint": "5.8.0",
     "typescript": "2.4.1"

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -144,6 +144,14 @@ export function Acl(...acl: string[]) {
     const parameterNames = functionArguments(execute)
     const types = Reflect.getMetadata('design:paramtypes', UserCommand, key)
 
+    if (!types) {
+        throw crash('Reflect.getMetadata returned null.\
+        Did you set experimentalDecorators and emitDecoratorMetadata to true in your tsconfig.json ?', {
+            method: key,
+            userCommand: UserCommand
+        })
+    }
+
     // We extract the state information, since we won't need it
     parameterNames.shift()
     types.shift()

--- a/test/usercommand/acl-decorator/MisconfiguredTsconfig.ts
+++ b/test/usercommand/acl-decorator/MisconfiguredTsconfig.ts
@@ -1,0 +1,45 @@
+/* tslint:disable:no-console */
+import * as mage from 'mage'
+import * as assert from 'assert'
+import { Acl } from '../../../src'
+
+const sinon = require('sinon')
+
+let state: mage.core.IState
+let reflectStub: any
+
+describe('MisconfiguredTsconfig', function () {
+  before(() => {
+    state = new mage.core.State()
+    reflectStub  = sinon.stub(Reflect, 'getMetadata').returns(null)
+  })
+
+  after(() => {
+    reflectStub.restore()
+  })
+
+  // If experimentalDecorators or emitDecoratorMetadata are not set
+  // in tsconfig.json, Reflect.getMetadata returns null
+  //
+  // We test it correctly throws an error in this case
+  it('Throws an error if tsconfig is misconfigured', async function () {
+    try {
+    /**
+     * Empty class for testing purpose
+     *
+     * @class UserCommand
+     */
+      class UserCommand {
+        @Acl('*')
+        public static async execute(_state: mage.core.IState) {
+          return true
+        }
+      }
+      assert(UserCommand)
+    } catch (err) {
+      return
+    }
+
+    throw new Error('Should throw an error')
+  })
+})

--- a/test/usercommand/acl-decorator/index.ts
+++ b/test/usercommand/acl-decorator/index.ts
@@ -4,4 +4,5 @@ describe('@acl decorator', function () {
   require('./ScalarInputUserCommand')
   require('./NestedDataUserCommand')
   require('./NestedTopicUserCommand')
+  require('./MisconfiguredTsconfig')
 })


### PR DESCRIPTION
When getting function param types using Reflect.getMetadata, throws an error if return null, which means experimentalDecorators or emitDecoratorMetadata have not been set in tsconfig.json.